### PR TITLE
docs: add OpenRouter to skills, create troubleshooting guide

### DIFF
--- a/.claude/commands/council.md
+++ b/.claude/commands/council.md
@@ -55,6 +55,13 @@ Return the complete markdown output to display to the user."
 
 2. **Available models**:
 
+   **OpenRouter** (hundreds of models via single API key — requires OPENROUTER_API_KEY):
+   - `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4`
+   - `openai/gpt-5.3-codex`, `openai/gpt-4o`
+   - `google/gemini-3.1-pro-preview`, `google/gemini-2.5-pro-preview`
+   - `x-ai/grok-4`
+   - Plus hundreds more (use `llm-council --list-models` to discover)
+
    **Bedrock** (any model in your region — requires AWS credentials):
    - Claude Opus 4.6 (`us.anthropic.claude-opus-4-6-v1:0`)
    - Claude Sonnet 4 (`us.anthropic.claude-sonnet-4-20250514-v1:0`)
@@ -74,21 +81,27 @@ Return the complete markdown output to display to the user."
 
 Location: `.claude/council-config.json`
 
+Default config (all OpenRouter):
+
 ```json
 {
   "council_models": [
-    {"name": "Claude Opus 4.6", "provider": "bedrock", "model_id": "us.anthropic.claude-opus-4-6-v1:0"},
-    {"name": "GPT-5.3-Codex", "provider": "poe", "bot_name": "GPT-5.3-Codex"},
-    {"name": "Gemini-3.1-Pro", "provider": "poe", "bot_name": "Gemini-3.1-Pro"},
-    {"name": "Grok-4", "provider": "poe", "bot_name": "Grok-4"}
+    {"name": "Claude Opus 4.6", "provider": "openrouter", "model_id": "anthropic/claude-opus-4.6", "reasoning_max_tokens": 16000, "max_tokens": 32000},
+    {"name": "GPT-5.3-Codex", "provider": "openrouter", "model_id": "openai/gpt-5.3-codex", "reasoning_effort": "high", "max_tokens": 32000},
+    {"name": "Gemini-3.1-Pro", "provider": "openrouter", "model_id": "google/gemini-3.1-pro-preview", "reasoning_effort": "high", "max_tokens": 32000},
+    {"name": "Grok 4", "provider": "openrouter", "model_id": "x-ai/grok-4", "reasoning_effort": "high", "max_tokens": 32000}
   ],
   "chairman": {
     "name": "Claude Opus 4.6",
-    "provider": "bedrock",
-    "model_id": "us.anthropic.claude-opus-4-6-v1:0"
+    "provider": "openrouter",
+    "model_id": "anthropic/claude-opus-4.6",
+    "reasoning_max_tokens": 16000,
+    "max_tokens": 32000
   }
 }
 ```
+
+Bedrock and Poe models can also be used. See the README for alternative config examples.
 
 ## Output Format
 
@@ -119,8 +132,11 @@ The council returns a markdown summary:
 
 ## Requirements
 
-- **AWS credentials** configured for Bedrock access (Claude models)
-- **POE_API_KEY** environment variable for Poe.com models (GPT, Gemini, Grok)
+- **OPENROUTER_API_KEY** environment variable for OpenRouter models (default config)
+- **POE_API_KEY** environment variable for Poe.com models (if using Poe provider)
+- **AWS credentials** configured for Bedrock access (if using Bedrock provider)
+
+You only need keys for providers in your config.
 
 ## Error Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,11 +26,13 @@ LLM Council runs multi-model deliberation with anonymized peer review. It querie
 2. **Stage 2**: Models rank responses using anonymous labels (Response A/B/C)
 3. **Stage 3**: Chairman synthesizes final answer based on rankings
 
-### Hybrid Provider Strategy
+### Provider Strategy
 
-- **Bedrock**: Claude Opus 4.6 (council member + chairman)
-- **Poe.com**: GPT-5.3-Codex, Gemini-3.1-Pro, Grok-4
-- **OpenRouter**: Any model via OpenAI-compatible API (real token usage reporting)
+The default config uses **OpenRouter** for all models (single API key, real token usage reporting). Alternative providers:
+
+- **AWS Bedrock**: Native AWS auth, extended thinking via `budget_tokens`
+- **Poe.com**: Single API key covers GPT, Gemini, Grok, and community bots
+- **OpenRouter**: OpenAI-compatible API, model discovery via `--list-models`
 
 ### Provider Abstraction
 
@@ -38,100 +40,78 @@ Providers (Bedrock, Poe, OpenRouter) are implemented as classes behind a common 
 
 ### Key Files
 
+See [Package Structure](README.md#package-structure) in the README for the full module listing. Core files:
+
 ```
-src/llm_council/                      # Main package
-├── __init__.py                       # Package initialization
-├── cli.py                            # CLI entry point
-├── council.py                        # Council orchestration
-├── stages.py                         # 3-stage deliberation logic
-├── providers/                        # Provider implementations
-│   ├── __init__.py
-│   ├── base.py                       # Provider protocol
-│   ├── bedrock.py                    # AWS Bedrock provider
-│   ├── poe.py                        # Poe.com provider
-│   └── openrouter.py                 # OpenRouter provider
-├── aggregation.py                    # Ranking aggregation algorithms
-├── flattener.py                      # Project directory flattener
-├── parsing.py                        # Response parsing utilities
-├── security.py                       # Injection hardening
-├── formatting.py                     # Output formatting
-├── progress.py                       # Progress visualization
-├── cost.py                           # Cost tracking
-└── models.py                         # Data models
+src/llm_council/
+├── cli.py                  # CLI entry point, argparse flags, config loading
+├── council.py              # Main orchestrator: validate_config, run_council
+├── stages.py               # 3-stage pipeline logic: collect, rank, synthesize
+├── models.py               # Pydantic config models and result types
+├── context.py              # Per-run dependency-injection container
+├── providers/              # Provider implementations (Bedrock, Poe, OpenRouter)
+├── aggregation.py          # Borda count, bootstrap confidence intervals
+├── budget.py               # Token and cost budget guards
+├── cache.py                # SQLite response cache for Stage 1
+├── security.py             # Input sanitization, injection detection, nonce fencing
+├── prompts.py              # Prompt templates for ranking and synthesis
+└── formatting.py           # Markdown output formatting
 
-tests/                                 # Test suite
-├── test_aggregation.py
-├── test_config.py
-├── test_council_integration.py
-├── test_parsing.py
-├── test_resilience.py
-└── test_security.py
+.claude/
+├── commands/council.md     # Claude Code skill command definition
+├── skills/council/scripts/council.py  # Skill wrapper script
+└── council-config.json     # Model configuration
 
-.claude/                              # Claude Code skill
-├── skills/council/
-│   ├── commands/
-│   │   └── council.md                # Skill command definition
-│   └── scripts/
-│       └── council.py                # Skill wrapper script
-└── council-config.json               # Model configuration
-
-skills/                               # OpenClaw skill
-└── council/
-    ├── SKILL.md                      # OpenClaw skill manifest
-    ├── scripts/
-    │   └── council.py → (symlink)    # Shared script
-    └── config/
-        └── council-config.json → (symlink)  # Shared config
+skills/council/             # OpenClaw skill (symlinks to shared script/config)
 ```
 
 ## Configuration
 
-Edit `.claude/council-config.json` to change models:
+Edit `.claude/council-config.json` to change models. The default config uses OpenRouter for all models:
 
 ```json
 {
   "council_models": [
     {
       "name": "Claude Opus 4.6",
-      "provider": "bedrock",
-      "model_id": "us.anthropic.claude-opus-4-6-v1:0",
-      "budget_tokens": 10000
+      "provider": "openrouter",
+      "model_id": "anthropic/claude-opus-4.6",
+      "reasoning_max_tokens": 16000,
+      "max_tokens": 32000
     },
     {
       "name": "GPT-5.3-Codex",
-      "provider": "poe",
-      "bot_name": "GPT-5.3-Codex",
-      "web_search": true,
-      "reasoning_effort": "high"
+      "provider": "openrouter",
+      "model_id": "openai/gpt-5.3-codex",
+      "reasoning_effort": "high",
+      "max_tokens": 32000
     },
     {
       "name": "Gemini-3.1-Pro",
-      "provider": "poe",
-      "bot_name": "Gemini-3.1-Pro",
-      "web_search": true,
-      "reasoning_effort": "high"
+      "provider": "openrouter",
+      "model_id": "google/gemini-3.1-pro-preview",
+      "reasoning_effort": "high",
+      "max_tokens": 32000
     },
-    {"name": "Grok-4", "provider": "poe", "bot_name": "Grok-4"}
+    {
+      "name": "Grok 4",
+      "provider": "openrouter",
+      "model_id": "x-ai/grok-4",
+      "reasoning_effort": "high",
+      "max_tokens": 32000
+    }
   ],
   "chairman": {
     "name": "Claude Opus 4.6",
-    "provider": "bedrock",
-    "model_id": "us.anthropic.claude-opus-4-6-v1:0",
-    "budget_tokens": 10000
+    "provider": "openrouter",
+    "model_id": "anthropic/claude-opus-4.6",
+    "reasoning_max_tokens": 16000,
+    "max_tokens": 32000
   }
 }
 ```
 
-### Enhanced Model Parameters
-
-| Provider | Parameter | Description |
-|----------|-----------|-------------|
-| Bedrock | `budget_tokens` | Extended thinking token budget (e.g., 10000) |
-| Poe | `web_search` | Enable web search (true/false) |
-| Poe | `reasoning_effort` | GPT: "medium"/"high"/"Xhigh", Gemini: "minimal"/"low"/"high" |
-| OpenRouter | `model_id` | OpenRouter model ID (e.g., "openai/gpt-4o") |
-| OpenRouter | `temperature` | Optional temperature (0.0-2.0) |
-| OpenRouter | `max_tokens` | Optional max output tokens |
+For the full configuration reference (all provider-specific fields, budget controls, cache settings, resilience tuning), see the [Configuration Reference](README.md#configuration-reference) in the README.
 
 ## Security
 
@@ -144,29 +124,11 @@ Edit `.claude/council-config.json` to change models:
 
 ## Requirements
 
-- **AWS credentials** configured for Bedrock (Claude models)
-- **POE_API_KEY** environment variable for Poe.com models
-- **OPENROUTER_API_KEY** environment variable for OpenRouter models
+- **OPENROUTER_API_KEY** for OpenRouter models (default config — single key covers all models)
+- **POE_API_KEY** for Poe.com models (if using Poe provider)
+- **AWS credentials** for Bedrock models (if using Bedrock provider)
 
-## Available Models
-
-Any model available on Bedrock, Poe.com, or OpenRouter can be used. Run `llm-council --list-models` to discover available models.
-
-### Bedrock
-Any model in your AWS Bedrock region (Anthropic, Meta, Mistral, Cohere, etc.). Examples:
-- `us.anthropic.claude-opus-4-6-v1:0` - Claude Opus 4.6 (supports extended thinking)
-- `us.anthropic.claude-sonnet-4-20250514-v1:0` - Claude Sonnet 4
-
-### Poe.com
-Any bot on Poe's API (hundreds of models including open-source). Examples:
-- `GPT-5.3-Codex`, `GPT-5.2` - supports web_search, reasoning_effort
-- `Gemini-3.1-Pro`, `Gemini-3-Flash` - supports web_search, reasoning_effort
-- `Grok-4`
-
-### OpenRouter
-Any model on OpenRouter's API (stable, OpenAI-compatible, real token usage). Examples:
-- `openai/gpt-4o`, `anthropic/claude-3.5-sonnet`, `google/gemini-pro`
-- `meta-llama/llama-3-70b`, `mistralai/mixtral-8x7b`
+You only need keys for the providers in your config. Run `llm-council --list-models` to discover available models. See the [README](README.md#available-models) for the full model list.
 
 ## Direct Usage
 
@@ -213,7 +175,7 @@ clawhub install council
 
 ### Configuration
 
-Set `POE_API_KEY` via OpenClaw's skill config injection:
+Set your API key via OpenClaw's skill config injection. The default config uses OpenRouter:
 
 ```json5
 {
@@ -221,25 +183,25 @@ Set `POE_API_KEY` via OpenClaw's skill config injection:
     entries: {
       council: {
         enabled: true,
-        apiKey: "YOUR_POE_API_KEY",
+        apiKey: "YOUR_OPENROUTER_API_KEY",
       },
     },
   },
 }
 ```
 
-AWS credentials for Bedrock should be configured via `aws configure` or environment variables as usual.
+For Poe models, set `POE_API_KEY` instead. For Bedrock, configure AWS credentials via `aws configure` or environment variables.
 
 ## Key Design Decisions
 
 ### Anonymized Peer Review
 Models receive "Response A", "Response B", etc. instead of model names. This prevents bias where models might favor their own family or disfavor competitors.
 
-### Hybrid Providers
-Bedrock for Anthropic models (already configured, no extra API key). Poe.com for others (single API key covers GPT, Gemini, Grok). OpenRouter as an alternative stable API with real token usage reporting.
+### Multi-Provider Support
+OpenRouter as default (single key, real token usage, broadest model access). Bedrock for direct AWS integration and extended thinking. Poe for access to community bots and web search augmentation.
 
 ### Subagent Execution
 The skill spawns a subagent to run the council, preserving the main conversation's context window.
 
 ### Graceful Degradation
-If a model fails, the council continues with remaining models rather than failing entirely.
+If a model fails, the council continues with remaining models rather than failing entirely. Circuit breakers skip consistently failing models. See [Troubleshooting](docs/TROUBLESHOOTING.md) for common errors and fixes.

--- a/docs/GAPS.md
+++ b/docs/GAPS.md
@@ -118,7 +118,7 @@ Alternatively, [Sphinx](https://www.sphinx-doc.org/) with `autodoc` and the `nap
 - **Skill versioning and updates:** Neither `.claude/commands/council.md` nor `skills/council/SKILL.md` document how users should handle skill updates when the upstream project changes. There is no guidance on re-syncing skill files after a `git pull`.
 - **Skill-specific troubleshooting:** The skill files document basic error handling (model failure, missing config, missing credentials) but lack detailed troubleshooting steps — e.g., what to do when the skill script fails silently, how to enable verbose output from within a skill invocation, or how to debug `{baseDir}` path resolution issues in OpenClaw.
 - **Shared script divergence:** The README documents that `.claude/skills/council/scripts/council.py` and `skills/council/scripts/council.py` share the same underlying script, but there is no mechanism or documentation for keeping them in sync (e.g., a symlink strategy or a CI check).
-- **OpenRouter support in skills:** The skill files (`.claude/commands/council.md`, `skills/council/SKILL.md`) document Bedrock and Poe models but do not mention OpenRouter as a provider option in the config mode instructions, even though the core library supports it.
+- ~~**OpenRouter support in skills:** The skill files (`.claude/commands/council.md`, `skills/council/SKILL.md`) document Bedrock and Poe models but do not mention OpenRouter as a provider option in the config mode instructions, even though the core library supports it.~~ **RESOLVED** — OpenRouter added to both skill files with model examples, config examples, and parameter tables.
 - **Plugin metadata:** `.claude/skills/council/.claude-plugin/` contains `marketplace.json` and `plugin.json` but these files are not documented anywhere — their purpose, schema, and how to update them is unclear.
 
 **Why it matters:** Skill-based usage is the primary interaction mode for most users. Gaps in skill documentation directly impact the majority of the user base.
@@ -131,9 +131,11 @@ Alternatively, [Sphinx](https://www.sphinx-doc.org/) with `autodoc` and the `nap
 
 ---
 
-## 5. Troubleshooting Guide
+## ~~5. Troubleshooting Guide~~ **RESOLVED**
 
-**What's missing:** There is no dedicated troubleshooting guide covering common errors users encounter when running the council.
+**RESOLVED** — Created `docs/TROUBLESHOOTING.md` covering: missing API keys, AWS credentials, model not found, budget exceeded, timeout errors, stale cache, invalid config, ranking parse failures, circuit breaker behavior, and debugging tips.
+
+~~**What's missing:** There is no dedicated troubleshooting guide covering common errors users encounter when running the council.~~
 
 **Why it matters:** Users hitting errors often abandon tools rather than debugging them. A troubleshooting guide with clear symptoms, causes, and fixes dramatically reduces support burden and improves the onboarding experience.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,130 @@
+# Troubleshooting
+
+Common errors and how to fix them.
+
+## Missing API Keys
+
+**Symptom:** `OPENROUTER_API_KEY not set` or `POE_API_KEY not set`
+
+**Cause:** The environment variable for your provider isn't configured.
+
+**Fix:** Set the variable in your shell profile or `.env` file:
+
+```bash
+export OPENROUTER_API_KEY=your-key   # Default config uses OpenRouter
+export POE_API_KEY=your-key          # Only if using Poe provider
+```
+
+You only need keys for providers in your `council-config.json`. The default config requires only `OPENROUTER_API_KEY`.
+
+## AWS Credentials
+
+**Symptom:** `NoCredentialsError` or `ExpiredTokenError` when using Bedrock models.
+
+**Cause:** AWS CLI not configured or session expired.
+
+**Fix:**
+
+```bash
+aws configure           # Set up credentials
+aws sso login           # Or refresh SSO session
+```
+
+## Model Not Found
+
+**Symptom:** `Model 'xyz' not found`, `ValidationException`, or `404` from OpenRouter.
+
+**Cause:** Typo in `model_id`, model not available in your region (Bedrock), or bot name changed (Poe).
+
+**Fix:**
+- Run `llm-council --list-models` to see available models
+- For Bedrock: verify the model is enabled in your AWS region
+- For OpenRouter: check the model ID at [openrouter.ai/models](https://openrouter.ai/models)
+- For Poe: verify the bot name on poe.com
+
+## Budget Exceeded
+
+**Symptom:** `BudgetExceededError` or council stops mid-run.
+
+**Cause:** The `max_cost_usd` or `max_tokens` limit in the `budget` config section was reached.
+
+**Fix:** Increase the limits or remove the `budget` section entirely:
+
+```json
+{
+  "budget": {
+    "max_tokens": 500000,
+    "max_cost_usd": 5.0
+  }
+}
+```
+
+To disable budget limits, omit the `budget` key from your config.
+
+## Timeout Errors
+
+**Symptom:** `asyncio.TimeoutError` or models returning no response.
+
+**Cause:** A model is taking too long; network issues.
+
+**Fix:**
+- Increase `soft_timeout` in your config (default: 300 seconds)
+- The circuit breaker automatically skips models that fail 3 times consecutively (see [Resilience](#resilience-circuit-breakers-and-retries) below)
+- Set `min_responses` in config to proceed with partial results before all models respond
+
+## Stale Cache Results
+
+**Symptom:** Getting old responses even after changing your question or config.
+
+**Cause:** Cached Stage 1 responses from a previous run.
+
+**Fix:**
+
+```bash
+llm-council --clear-cache          # Delete all cached responses
+llm-council --no-cache "question"  # Bypass cache for one run
+llm-council --cache-ttl 0 "question"  # Bypass reads, still writes new entries
+```
+
+Check cache status with `llm-council --cache-stats`.
+
+## Invalid Config
+
+**Symptom:** `ValidationError` on startup with a list of field errors.
+
+**Cause:** Malformed JSON or invalid field values in `council-config.json`.
+
+**Fix:**
+- Validate JSON syntax (trailing commas, missing quotes)
+- Check field names against the [Configuration Reference](../README.md#configuration-reference)
+- Ensure `council_models` has at least one entry
+- Ensure `budget_tokens` (Bedrock) is between 1024 and 128000
+
+## Ranking Parse Failures
+
+**Symptom:** `No valid ballots` warning, low ballot count in output, or unexpected rankings.
+
+**Cause:** Models returning rankings in an unparseable format.
+
+**Fix:**
+- Increase `stage2_retries` in config (default: 1, max: 5) to give models more attempts
+- Enable `strict_ballots` in config to reject partial or ambiguous rankings
+- Check raw model responses with `--log-dir ./logs` and inspect the JSONL files
+- Run with `-v` for verbose logging to see ballot parsing details
+
+## Resilience: Circuit Breakers and Retries
+
+LLM Council includes automatic resilience mechanisms:
+
+- **Circuit breaker:** After 3 consecutive failures from a model, that model is skipped for 60 seconds before retrying. This prevents wasting time and tokens on a consistently failing provider.
+- **Soft timeout:** If `soft_timeout` expires and at least `min_responses` models have responded, the pipeline proceeds without waiting for stragglers.
+- **Stage 2 retries:** Invalid ranking ballots are retried up to `stage2_retries` times (default: 1).
+- **Graceful degradation:** If a model fails entirely, the council continues with the remaining models rather than failing the whole run.
+
+## Debugging Tips
+
+- Use `-v` (verbose) to see DEBUG-level logs on stderr
+- Use `--manifest` to see the full run manifest (config hash, timestamps, model list) on stderr
+- Use `--log-dir ./logs` to persist complete JSONL logs for post-mortem analysis
+- Use `--dry-run` to preview config and estimated API calls without spending tokens
+- Use `--stage 1` to test just the response collection stage

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -3,7 +3,7 @@ name: council
 description: Multi-model LLM council with anonymized peer review
 user-invocable: true
 homepage: https://github.com/0ri/llm-council
-metadata: {"openclaw": {"emoji": "🏛️", "requires": {"bins": ["uv", "python3"], "env": ["POE_API_KEY"]}, "primaryEnv": "POE_API_KEY", "install": [{"id": "uv", "kind": "brew", "formula": "uv", "bins": ["uv"], "label": "Install uv (brew)"}]}}
+metadata: {"openclaw": {"emoji": "🏛️", "requires": {"bins": ["uv", "python3"], "env": ["OPENROUTER_API_KEY"]}, "primaryEnv": "OPENROUTER_API_KEY", "install": [{"id": "uv", "kind": "brew", "formula": "uv", "bins": ["uv"], "label": "Install uv (brew)"}]}}
 ---
 
 # LLM Council
@@ -40,6 +40,13 @@ The output will include:
 
 2. **Ask the user which models to include** in the council (multi-select):
 
+   **OpenRouter** (hundreds of models via single API key — requires OPENROUTER_API_KEY):
+   - `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4` - supports reasoning_max_tokens
+   - `openai/gpt-5.3-codex`, `openai/gpt-4o` - supports reasoning_effort
+   - `google/gemini-3.1-pro-preview` - supports reasoning_effort
+   - `x-ai/grok-4` - supports reasoning_effort
+   - Plus hundreds more (use `llm-council --list-models` to discover)
+
    **Bedrock** (any model in your region — requires AWS credentials):
    - Claude Opus 4.6 (`us.anthropic.claude-opus-4-6-v1:0`) - supports budget_tokens
    - Claude Sonnet 4 (`us.anthropic.claude-sonnet-4-20250514-v1:0`)
@@ -54,9 +61,11 @@ The output will include:
 3. **Ask which model should be chairman** (single select from the chosen council models)
 
 4. **Ask about enhanced parameters** for selected models:
-   - For Claude models: budget_tokens (e.g., 10000 for extended thinking)
-   - For GPT models: web_search (true/false), reasoning_effort (medium/high/Xhigh)
-   - For Gemini models: web_search (true/false), reasoning_effort (minimal/low/high; sent as thinking_level)
+   - For OpenRouter Claude models: reasoning_max_tokens, max_tokens
+   - For OpenRouter GPT/Gemini/Grok models: reasoning_effort (minimal/low/medium/high/xhigh), max_tokens
+   - For Bedrock Claude models: budget_tokens (e.g., 10000 for extended thinking)
+   - For Poe GPT models: web_search (true/false), reasoning_effort (medium/high/Xhigh)
+   - For Poe Gemini models: web_search (true/false), reasoning_effort (minimal/low/high; sent as thinking_level)
 
 5. **Save the configuration** to `{baseDir}/config/council-config.json` with this format:
 
@@ -65,34 +74,44 @@ The output will include:
   "council_models": [
     {
       "name": "Claude Opus 4.6",
-      "provider": "bedrock",
-      "model_id": "us.anthropic.claude-opus-4-6-v1:0",
-      "budget_tokens": 10000
+      "provider": "openrouter",
+      "model_id": "anthropic/claude-opus-4.6",
+      "reasoning_max_tokens": 16000,
+      "max_tokens": 32000
     },
     {
       "name": "GPT-5.3-Codex",
-      "provider": "poe",
-      "bot_name": "GPT-5.3-Codex",
-      "web_search": true,
-      "reasoning_effort": "high"
+      "provider": "openrouter",
+      "model_id": "openai/gpt-5.3-codex",
+      "reasoning_effort": "high",
+      "max_tokens": 32000
     },
     {
       "name": "Gemini-3.1-Pro",
-      "provider": "poe",
-      "bot_name": "Gemini-3.1-Pro",
-      "web_search": true,
-      "reasoning_effort": "high"
+      "provider": "openrouter",
+      "model_id": "google/gemini-3.1-pro-preview",
+      "reasoning_effort": "high",
+      "max_tokens": 32000
     },
-    {"name": "Grok-4", "provider": "poe", "bot_name": "Grok-4"}
+    {
+      "name": "Grok 4",
+      "provider": "openrouter",
+      "model_id": "x-ai/grok-4",
+      "reasoning_effort": "high",
+      "max_tokens": 32000
+    }
   ],
   "chairman": {
     "name": "Claude Opus 4.6",
-    "provider": "bedrock",
-    "model_id": "us.anthropic.claude-opus-4-6-v1:0",
-    "budget_tokens": 10000
+    "provider": "openrouter",
+    "model_id": "anthropic/claude-opus-4.6",
+    "reasoning_max_tokens": 16000,
+    "max_tokens": 32000
   }
 }
 ```
+
+Bedrock and Poe models can also be used. See the project README for alternative config examples.
 
 6. **Confirm** the configuration was saved successfully
 
@@ -127,15 +146,23 @@ The council returns a markdown summary with:
 
 | Provider | Parameter | Description |
 |----------|-----------|-------------|
-| Bedrock | `budget_tokens` | Extended thinking token budget (e.g., 10000) |
+| OpenRouter | `model_id` | OpenRouter model ID (e.g., `anthropic/claude-opus-4.6`) |
+| OpenRouter | `reasoning_effort` | `minimal` / `low` / `medium` / `high` / `xhigh` |
+| OpenRouter | `reasoning_max_tokens` | Token budget for reasoning (Anthropic, Qwen models) |
+| OpenRouter | `max_tokens` | Max output tokens |
+| OpenRouter | `temperature` | Sampling temperature (0.0-2.0) |
+| Bedrock | `budget_tokens` | Extended thinking token budget (1024-128000) |
 | Poe | `web_search` | Enable web search (true/false) |
 | Poe | `reasoning_effort` | GPT: "medium"/"high"/"Xhigh", Gemini: "minimal"/"low"/"high" |
 
 ## Requirements
 
-- **AWS credentials** must be configured for Bedrock access (Claude models)
-- **POE_API_KEY** environment variable required for Poe.com models (GPT, Gemini, Grok)
+- **OPENROUTER_API_KEY** environment variable for OpenRouter models (default config)
   - This is injected by OpenClaw via skill configuration
+- **POE_API_KEY** environment variable for Poe.com models (if using Poe provider)
+- **AWS credentials** for Bedrock models (if using Bedrock provider)
+
+You only need keys for providers in your config.
 
 ## Error Handling
 


### PR DESCRIPTION
## Changes

- **Updated skill documentation** (`.claude/commands/council.md`, `skills/council/SKILL.md`)
  - Added OpenRouter as primary provider with model examples
  - Updated default config to use OpenRouter for all models
  - Added parameter tables for all providers
  - Clarified API key requirements

- **Created comprehensive troubleshooting guide** (`docs/TROUBLESHOOTING.md`)
  - Common errors: missing API keys, AWS credentials, model not found, budget exceeded, timeouts
  - Cache troubleshooting and stale cache clearing
  - Config validation and ranking parse failures
  - Resilience mechanisms: circuit breakers, retries, graceful degradation
  - Debugging tips with flags and log collection

- **Updated core documentation** (`CLAUDE.md`)
  - Simplified provider strategy; OpenRouter now default
  - Streamlined configuration examples
  - Consolidated requirements and model list references
  - Added link to troubleshooting guide

- **Marked documentation gap as resolved** (`docs/GAPS.md`)
  - OpenRouter support in skills ✓
  - Troubleshooting guide ✓

All docs now consistent on OpenRouter as the recommended default provider.